### PR TITLE
Added support for loading and parsing DH Prime from the PEM file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 *.json
 *keys
 *cache*
+.idea/

--- a/cpwebapi/session.py
+++ b/cpwebapi/session.py
@@ -22,6 +22,7 @@ from .oauth_utils import (
     generate_hmac_sha_256_signature,
     validate_live_session_token,
     OAuthConfig,
+    read_and_parse_dh_pem_file,
 )
 
 # Disable insecure request warnings when connecting via Gateway
@@ -552,7 +553,7 @@ class OAuthSession(APISession):
         self.consumer_key = self.__oauth_config.consumer_key
         self.access_token = self.__oauth_config.access_token
         self.access_token_secret = self.__oauth_config.access_token_secret
-        self.dh_prime = self.__oauth_config.dh_prime
+        self.dh_prime = read_and_parse_dh_pem_file(self.__oauth_config.dh_param_fp).parameter_numbers().p
         self.realm = self.__oauth_config.realm
         self.live_session_token = live_session_token
         self.live_session_token_expiration = live_session_token_expiry

--- a/oauth_example.py
+++ b/oauth_example.py
@@ -1,8 +1,10 @@
 from cpwebapi import session, oauth_utils
 import json
 
+trading_env: str = "ppr"
+
 # Load the OAuth config from a file
-config_file_path = "config.json"
+config_file_path = f"config.{trading_env}.json"
 with open(config_file_path, "r") as f:
     oauth_config = json.load(f, object_hook=oauth_utils.oauth_config_hook)
 # Initialise the OAuth session


### PR DESCRIPTION
Eliminates the "openssl asn1parse < dhparam.pem" step, which is not even mentioned in the IB directions when someone goes to enable OAuth at https://ndcdyn.interactivebrokers.com/oauth/?action=OAUTH.